### PR TITLE
Gluster service and snmp test update

### DIFF
--- a/web/alerting/alerting_via_snmp.rst
+++ b/web/alerting/alerting_via_snmp.rst
@@ -56,7 +56,11 @@ Test Steps
        the client machine.
    :result:
        On the client machine, you should be able to see all notifications
-       Tendrl is sending as SNMPv3 trap messages:
+       Tendrl is sending as SNMPv3 trap messages.
+
+       In case of Status and utilization alerts for which a clearing alert
+       exists, snmp trap should be send repeatedly untill the clearing alert
+       is generated.
 
        .. code-block:: console
 

--- a/web/alerting/status_gluster_service.rst
+++ b/web/alerting/status_gluster_service.rst
@@ -3,6 +3,8 @@ Status of Gluster Service
 
 :author: mbukatov@redhat.com
 
+         ltrilety@redhat.com
+
 Description
 ===========
 
@@ -18,7 +20,32 @@ Based on:
 Setup
 =====
 
-#. You need a gluster volume.
+#. You need a gluster trusted pool.
+
+Test Steps
+==========
+
+.. test_action::
+    :step:
+        On some of gluster nodes stop *glusterd* service
+
+        .. code-block:: console
+
+            # systemctl stop glusterd
+    :result:
+        A *glusterd* service is stopped. Verify that after some time **Tendrl**
+        generates an (warning) alert for this event.
+
+.. test_action::
+    :step:
+        Start *glusterd* service again
+
+        .. code-block:: console
+
+            # systemctl start glusterd
+    :result:
+        Service is started. Verify that **Tendrl** generates a clearing (info)
+        alert and the previous (warning) one is not displayed on UI anymore.
 
 Teardown
 ========


### PR DESCRIPTION
- **Update snmp test case**
  check for repeating snmp traps for status and utilization alerts for which a clearing alert exists

- **Update Status of Gluster Service test**
  add some steps and their expected results